### PR TITLE
Tests: fix join lines

### DIFF
--- a/include/qutepart/qutepart.h
+++ b/include/qutepart/qutepart.h
@@ -412,6 +412,10 @@ class Qutepart : public QPlainTextEdit {
     auto fixLineFlagColors() -> void;
 
     // Actions
+    inline QAction *homeAction() const { return homeAction_; }
+    inline QAction *homeSelectAction() const { return homeSelectAction_; }
+    inline QAction *endAction() const { return endAction_; }
+    inline QAction *endSelectAction() const { return endSelectAction_; }
     inline QAction *increaseIndentAction() const { return increaseIndentAction_; }
     inline QAction *decreaseIndentAction() const { return decreaseIndentAction_; }
     inline QAction *toggleBookmarkAction() const { return toggleBookmarkAction_; }

--- a/test/test_edit_operations.cpp
+++ b/test/test_edit_operations.cpp
@@ -17,60 +17,58 @@ class Test : public QObject {
     void SmartHome() {
         Qutepart::Qutepart qpart(nullptr, "one\n    two");
 
-        QTest::keyClick(&qpart, Qt::Key_Home);
+        qpart.homeAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 0);
 
-        QTest::keyClick(&qpart, Qt::Key_Home);
+        qpart.homeAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 0);
 
         qpart.goTo(1, 2);
-        QTest::keyClick(&qpart, Qt::Key_Home);
+        qpart.homeAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 4);
 
-        QTest::keyClick(&qpart, Qt::Key_Home);
+        qpart.homeAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 0);
 
-        QTest::keyClick(&qpart, Qt::Key_Home);
+        qpart.homeAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 4);
     }
 
     void SmartHomeSelect() {
         Qutepart::Qutepart qpart(nullptr, "one\n    two");
 
-        QTest::keyClick(&qpart, Qt::Key_Home, Qt::ShiftModifier);
+        qpart.homeSelectAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 0);
         QCOMPARE(qpart.textCursor().selectedText(), QString());
 
-        QTest::keyClick(&qpart, Qt::Key_Home, Qt::ShiftModifier);
+        qpart.homeSelectAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 0);
         QCOMPARE(qpart.textCursor().selectedText(), QString());
 
         qpart.goTo(1, 6);
-        QTest::keyClick(&qpart, Qt::Key_Home, Qt::ShiftModifier);
+        qpart.homeSelectAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 4);
         QCOMPARE(qpart.textCursor().selectedText(), QString("tw"));
 
-        QTest::keyClick(&qpart, Qt::Key_Home, Qt::ShiftModifier);
+        qpart.homeSelectAction()->trigger();
         QCOMPARE(qpart.textCursor().selectedText(), QString("    tw"));
         QCOMPARE(qpart.textCursor().positionInBlock(), 0);
-#if 0
-        QTest::keyClick(&qpart, Qt::Key_Home, Qt::ShiftModifier);
+
+        qpart.homeSelectAction()->trigger();
         QCOMPARE(qpart.textCursor().positionInBlock(), 4);
-        auto s = qpart.textCursor().selectedText();
         QCOMPARE(qpart.textCursor().selectedText(), QString("tw"));
-#endif
     }
 
     void JoinLines() {
         Qutepart::Qutepart qpart(nullptr, "one\ntwo\n    three");
 
-        QTest::keyClick(&qpart, Qt::Key_J, Qt::ControlModifier);
+        qpart.joinLinesAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one two\n    three"));
 
-        QTest::keyClick(&qpart, Qt::Key_J, Qt::ControlModifier);
+        qpart.joinLinesAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one two three"));
 
-        QTest::keyClick(&qpart, Qt::Key_J, Qt::ControlModifier);
+        qpart.joinLinesAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one two three"));
     }
 
@@ -83,13 +81,9 @@ class Test : public QObject {
         qpart.setTextCursor(cursor);
         QCOMPARE(qpart.textCursor().selectedText(), QString("ne"));
 
-#if 0
-        QTest::keyClick(&qpart, Qt::Key_J, Qt::ControlModifier);
+        qpart.joinLinesAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one two\n    three"));
-        // FIXME remove space from "ne ". Actually a bug, but will fix later (I
-        // hope)
-        QCOMPARE(qpart.textCursor().selectedText(), QString("ne "));
-#endif
+        QCOMPARE(qpart.textCursor().selectedText(), QString("ne"));
     }
 
     void JoinMultipleLines() {
@@ -101,11 +95,9 @@ class Test : public QObject {
         qpart.setTextCursor(cursor);
         QCOMPARE(qpart.textCursor().selectedText(), QString("ne\u2029two\u2029    t"));
 
-#if 0        
-        QTest::keyClick(&qpart, Qt::Key_J, Qt::ControlModifier);
+        qpart.joinLinesAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one two three"));
         QCOMPARE(qpart.textCursor().selectedText(), QString("ne two t"));
-#endif
     }
 };
 

--- a/test/test_line_edit_operations.cpp
+++ b/test/test_line_edit_operations.cpp
@@ -7,6 +7,7 @@
 #include <QDebug>
 #include <QObject>
 #include <QTest>
+#include <QApplication>
 
 #include "qutepart.h"
 
@@ -14,20 +15,19 @@ class Test : public QObject {
     Q_OBJECT
 
   private slots:
-#if 0    
     void MoveDownOneLine() {
         Qutepart::Qutepart qpart(nullptr, "one\ntwo\nthree\nfour");
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\none\nthree\nfour"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\nthree\none\nfour"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\nthree\nfour\none"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\nthree\nfour\none"));
 
         qpart.undo();
@@ -39,19 +39,19 @@ class Test : public QObject {
     void MoveDownOneLineEolAtEnd() {
         Qutepart::Qutepart qpart(nullptr, "one\ntwo\nthree\nfour\n");
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\none\nthree\nfour\n"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\nthree\none\nfour\n"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\nthree\nfour\none\n"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\nthree\nfour\n\none"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\nthree\nfour\n\none"));
 
         qpart.undo();
@@ -68,16 +68,16 @@ class Test : public QObject {
         QTest::keyClick(&qpart, Qt::Key_Right);
         QCOMPARE(qpart.textCursor().positionInBlock(), 1);
 
-        QTest::keyClick(&qpart, Qt::Key_Up, Qt::AltModifier);
+        qpart.moveLineUpAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\nfour\nthree"));
 
-        QTest::keyClick(&qpart, Qt::Key_Up, Qt::AltModifier);
+        qpart.moveLineUpAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\nfour\ntwo\nthree"));
 
-        QTest::keyClick(&qpart, Qt::Key_Up, Qt::AltModifier);
+        qpart.moveLineUpAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("four\none\ntwo\nthree"));
 
-        QTest::keyClick(&qpart, Qt::Key_Up, Qt::AltModifier);
+        qpart.moveLineUpAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("four\none\ntwo\nthree"));
 
         QCOMPARE(qpart.textCursor().positionInBlock(), 1);
@@ -92,13 +92,13 @@ class Test : public QObject {
         qpart.setTextCursor(cursor);
         QCOMPARE(qpart.textCursor().selectedText(), QString("ne\u2029tw"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("three\none\ntwo\nfour"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("three\nfour\none\ntwo"));
 
-        QTest::keyClick(&qpart, Qt::Key_Down, Qt::AltModifier);
+        qpart.moveLineDownAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("three\nfour\none\ntwo"));
 
         QCOMPARE(qpart.textCursor().selectedText(), QString("ne\u2029tw"));
@@ -118,13 +118,13 @@ class Test : public QObject {
         qpart.setTextCursor(cursor);
         QCOMPARE(qpart.textCursor().selectedText(), QString("ree\u2029fo"));
 
-        QTest::keyClick(&qpart, Qt::Key_Up, Qt::AltModifier);
+        qpart.moveLineUpAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\nthree\nfour\ntwo"));
 
-        QTest::keyClick(&qpart, Qt::Key_Up, Qt::AltModifier);
+        qpart.moveLineUpAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("three\nfour\none\ntwo"));
 
-        QTest::keyClick(&qpart, Qt::Key_Up, Qt::AltModifier);
+        qpart.moveLineUpAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("three\nfour\none\ntwo"));
 
         QCOMPARE(qpart.textCursor().selectedText(), QString("ree\u2029fo"));
@@ -138,10 +138,8 @@ class Test : public QObject {
     void DuplicateLine() {
         Qutepart::Qutepart qpart(nullptr, "one\ntwo\n   three\nfour");
 
-        QTextCursor cursor = qpart.textCursor();
-
         qpart.goTo(1, 2);
-        QTest::keyClick(&qpart, Qt::Key_D, Qt::AltModifier);
+        qpart.duplicateSelectionAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\ntwo\n   three\nfour"));
         QCOMPARE(qpart.textCursor().blockNumber(), 2);
         QCOMPARE(qpart.textCursor().positionInBlock(), 2);
@@ -150,10 +148,8 @@ class Test : public QObject {
     void DuplicateIndentedLine() {
         Qutepart::Qutepart qpart(nullptr, "one\ntwo\n   three\nfour");
 
-        QTextCursor cursor = qpart.textCursor();
-
         qpart.goTo(2);
-        QTest::keyClick(&qpart, Qt::Key_D, Qt::AltModifier);
+        qpart.duplicateSelectionAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\n   three\n   three\nfour"));
         QCOMPARE(qpart.textCursor().blockNumber(), 3);
         QCOMPARE(qpart.textCursor().positionInBlock(), 0);
@@ -168,7 +164,7 @@ class Test : public QObject {
         cursor.setPosition(10, QTextCursor::KeepAnchor);
         qpart.setTextCursor(cursor);
         QCOMPARE(qpart.textCursor().selectedText(), QString("wo\u2029th"));
-        QTest::keyClick(&qpart, Qt::Key_D, Qt::AltModifier);
+        qpart.duplicateSelectionAction()->trigger();
         QCOMPARE(qpart.textCursor().selectedText(), QString("wo\u2029th"));
 
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\nthwo\nthree\nfour"));
@@ -185,11 +181,11 @@ class Test : public QObject {
         cursor.setPosition(5, QTextCursor::KeepAnchor);
         qpart.setTextCursor(cursor);
 
-        QTest::keyClick(&qpart, Qt::Key_X, Qt::AltModifier);
+        qpart.cutLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("three\nfour"));
 
         QTest::keyClick(&qpart, Qt::Key_Down);
-        QTest::keyClick(&qpart, Qt::Key_V, Qt::AltModifier);
+        qpart.pasteLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("three\nfour\none\ntwo"));
 
         qpart.undo();
@@ -198,7 +194,7 @@ class Test : public QObject {
         qpart.undo();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\nthree\nfour"));
     }
-#endif
+
     void CutPasteLastLines() {
         Qutepart::Qutepart qpart(nullptr, "one\ntwo\nthree\nfour");
 
@@ -207,11 +203,11 @@ class Test : public QObject {
         cursor.setPosition(12);
         cursor.setPosition(17, QTextCursor::KeepAnchor);
         qpart.setTextCursor(cursor);
-#if 0
-        QTest::keyClick(&qpart, Qt::Key_X, Qt::AltModifier);
+
+        qpart.cutLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo"));
         QTest::keyClick(&qpart, Qt::Key_Down);
-        QTest::keyClick(&qpart, Qt::Key_V, Qt::AltModifier);
+        qpart.pasteLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\nthree\nfour"));
 
         qpart.undo();
@@ -219,7 +215,6 @@ class Test : public QObject {
 
         qpart.undo();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\nthree\nfour"));
-#endif
     }
 
     void CopyPasteSingleLine() {
@@ -230,11 +225,11 @@ class Test : public QObject {
         cursor.setPosition(2);
         qpart.setTextCursor(cursor);
 
-        QTest::keyClick(&qpart, Qt::Key_C, Qt::AltModifier);
+        qpart.copyLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\nthree\nfour"));
 
         QTest::keyClick(&qpart, Qt::Key_Down);
-        QTest::keyClick(&qpart, Qt::Key_V, Qt::AltModifier);
+        qpart.pasteLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\none\nthree\nfour"));
 
         qpart.undo();
@@ -249,12 +244,12 @@ class Test : public QObject {
         cursor.setPosition(17);
         qpart.setTextCursor(cursor);
 
-        QTest::keyClick(&qpart, Qt::Key_C, Qt::AltModifier);
+        qpart.copyLineAction()->trigger();
 
         QTest::keyClick(&qpart, Qt::Key_Up);
         QTest::keyClick(&qpart, Qt::Key_Up);
         QTest::keyClick(&qpart, Qt::Key_Up);
-        QTest::keyClick(&qpart, Qt::Key_V, Qt::AltModifier);
+        qpart.pasteLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\nfour\ntwo\nthree\nfour"));
 
         qpart.undo();
@@ -269,12 +264,12 @@ class Test : public QObject {
         cursor.setPosition(7);
         cursor.setPosition(10, QTextCursor::KeepAnchor);
         qpart.setTextCursor(cursor);
-#if 0
-        QTest::keyClick(&qpart, Qt::Key_Delete, Qt::AltModifier);
+
+        qpart.deleteLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one\nfour"));
         QCOMPARE(qpart.textCursor().block().text(), QString("four"));
         QCOMPARE(qpart.textCursorPosition().line, 1);
-        QTest::keyClick(&qpart, Qt::Key_Delete, Qt::AltModifier);
+        qpart.deleteLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("one"));
         QCOMPARE(qpart.textCursorPosition().line, 0);
 
@@ -283,33 +278,25 @@ class Test : public QObject {
 
         qpart.undo();
         QCOMPARE(qpart.toPlainText(), QString("one\ntwo\nthree\nfour"));
-#endif
     }
 
     void DeleteFirstLine() {
         Qutepart::Qutepart qpart(nullptr, "one\ntwo\nthree\nfour");
 
-        QTextCursor cursor = qpart.textCursor();
-#if 0
-        QTest::keyClick(&qpart, Qt::Key_Delete, Qt::AltModifier);
+        qpart.deleteLineAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString("two\nthree\nfour"));
-#endif
         QCOMPARE(qpart.textCursorPosition().line, 0);
     }
 
     void InsertLineAbove() {
         Qutepart::Qutepart qpart(nullptr, " one\n  two\n   three\n    four");
         qpart.goTo(2, 4);
-        QTest::keyClick(&qpart, Qt::Key_Return, Qt::ShiftModifier | Qt::ControlModifier);
+        qpart.insertLineAboveAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString(" one\n  two\n  \n   three\n    four"));
 #if 0 // FIXME this fails. "x" gets undone with the rest of operations
-        qDebug() << "type X" << qpart.toPlainText();
         QTest::keyClicks(&qpart, "x");
-        qDebug() << "typed X" << qpart.toPlainText();
         QCOMPARE(qpart.toPlainText(), QString(" one\n  two\n  x\n   three\n    four"));
-        qDebug() << "undo x";
         qpart.undo();
-        qDebug() << "undo X done" << qpart.toPlainText();
         QCOMPARE(qpart.toPlainText(), QString(" one\n  two\n  \n   three\n    four"));
 #endif
         qpart.undo();
@@ -319,7 +306,7 @@ class Test : public QObject {
     void InsertLineAboveFirst() {
         Qutepart::Qutepart qpart(nullptr, " one\n  two\n   three\n    four");
         qpart.goTo(0, 0);
-        QTest::keyClick(&qpart, Qt::Key_Return, Qt::ShiftModifier | Qt::ControlModifier);
+        qpart.insertLineAboveAction()->trigger();
         QTest::keyClicks(&qpart, "x");
         QCOMPARE(qpart.toPlainText(), QString("x\n one\n  two\n   three\n    four"));
         qpart.undo();
@@ -331,17 +318,13 @@ class Test : public QObject {
     void InsertLineBelow() {
         Qutepart::Qutepart qpart(nullptr, " one\n  two\n   three\n    four");
         qpart.goTo(2, 4);
-        QTest::keyClick(&qpart, Qt::Key_Return, Qt::ControlModifier);
+        qpart.insertLineBelowAction()->trigger();
         QCOMPARE(qpart.toPlainText(), QString(" one\n  two\n   three\n   \n    four"));
 
 #if 0 // FIXME this fails. "x" gets undone with the rest of operations
-        qDebug() << "type X" << qpart.toPlainText();
         QTest::keyClicks(&qpart, "x");
-        qDebug() << "typed X" << qpart.toPlainText();
         QCOMPARE(qpart.toPlainText(), QString(" one\n  two\n   three\n   x\n    four"));
-        qDebug() << "undo x";
         qpart.undo();
-        qDebug() << "undo X done" << qpart.toPlainText();
         QCOMPARE(qpart.toPlainText(), QString(" one\n  two\n   three\n   \n    four"));
 #endif
 


### PR DESCRIPTION
It seems that on unit tests, the pressing of multiple keys (alt+left) and similar is not predictable. Sometimes the widget looses focus.
    
Solution: expose the actions and call them directly, instead of simulating keyboard presses.

Also - small improvements to code.